### PR TITLE
Fixed 2021 Community List

### DIFF
--- a/community.md
+++ b/community.md
@@ -4,10 +4,10 @@ title: RobotPy Community
 
 # Feel free to add your team to this list!
 teamlist:
- 2021:
+  2021:
     '3200':
       code: https://github.com/Raptacon/Robot-2021
- 2020:
+  2020:
     '703': {}
     '3200':
       code: https://github.com/Raptacon/Robot-2020


### PR DESCRIPTION
Community team list no longer appeared on website, changed spacing from 2020 and 2021 on lines 7 and 10 to be consistent with past years in attempt to resolve issue.